### PR TITLE
pre-emptive tuning of chisq snr threshold

### DIFF
--- a/configuration/analysis.ini
+++ b/configuration/analysis.ini
@@ -1,9 +1,8 @@
-; PyCBC configuration for BNS-NSBH-BBH search on O1-ER9-ER10-02 data
+; PyCBC configuration for BNS-NSBH-BBH search on LIGO O1-ER9-ER10-02 data
 ;
 ; Documentation for running the workflow generator is here:
 ;
 ;    http://ligo-cbc.github.io/pycbc/releases/v1.2.0/html/workflow/pycbc_make_coinc_search_workflow.html
-
 
 
 [workflow]
@@ -49,11 +48,10 @@ splittable-method = IN_WORKFLOW
 splittable-exe-tag = splitbank
 
 [workflow-splittable-full_data]
-; empirically tuned on O2 OSG runtime data to give runtimes between 15 mins and 10 hours, mostly ~6 hours
 splittable-num-banks = 15
 
 [workflow-splittable-injections]
-; empirically tuned on O2 OSG runtime data to give runtimes between a few mins and ~10 hours, mostly >30 minutes
+; must be the same as full data if doing clustering over subbanks
 splittable-num-banks = 15
 
 [workflow-matchedfilter]
@@ -93,15 +91,11 @@ max-hierarchical-removal = 2
 [ligolw_combine_segments]
 
 [splitbank]
-; split the template bank up by chrip mass between jobs to ensure equal run time
+; split the template bank up by chirp mass between jobs for clustering reasons
 mchirp-sort =
 
 [inspiral]
 ; parameters for matched filtering
-
-; sine-Gaussian chisq
-sgchisq-snr-threshold = 6.0
-sgchisq-locations = "mtotal>30:20-15,20-30,20-45,20-60,20-75,20-90,20-105,20-120"
 
 ; amount of buffer data for letting filters settle
 pad-data = 8
@@ -169,9 +163,15 @@ cluster-window = 1
 cluster-function = symmetric
 
 ; signal-based vetoes
-chisq-snr-threshold = 5.5
+
+; chisq evaluation threshold tuned to avoid bumps in the newsnr distribution
+chisq-snr-threshold = 5.25
 chisq-bins = "0.72*get_freq('fSEOBNRv4Peak',params.mass1,params.mass2,params.spin1z,params.spin2z)**0.7"
 newsnr-threshold = 4.0
+
+; sine-Gaussian chisq
+sgchisq-snr-threshold = 6.0
+sgchisq-locations = "mtotal>30:20-15,20-30,20-45,20-60,20-75,20-90,20-105,20-120"
 
 ; options for reducing the computational cost and storage
 filter-inj-only = 


### PR DESCRIPTION
chisq snr threshold of 5.5 produces a 'bump' in the newsnr distribution which makes it difficult to fit a background model at low stat values, hence tweak downwards to 5.25.  See e.g. https://gw-astro.slack.com/files/U8X4PDDS4/FKDNG4R5J/image.png

also a couple of other comment cleanups / reordering inspiral options